### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,6 +30,11 @@ class ItemsController < ApplicationController
   def show
   end
 
+  def order
+    ItemOrder.create(item_id: params[:id])
+  end
+
+
   private
 
   def item_params
@@ -38,5 +43,9 @@ class ItemsController < ApplicationController
 
   def move_to_index
     redirect_to action: :index unless user_signed_in?
+  end
+
+  def find_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :address_origin
   belongs_to_active_hash :burden
   belongs_to :user
+  has_one :item_order
   has_one_attached :image
 
   with_options presence: true do

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,0 +1,3 @@
+class ItemOrder < ApplicationRecord
+  belongs_to :item
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,26 +125,29 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+    <% @items.each do |item| %>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
+          <% if item.item_order != nil %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <% end %>
           <%# //商品が売れていればsold outの表示 %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +156,7 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   resources :items
+  resources :items, only: :order do
+    post 'order', on: :member
+  end
 end

--- a/db/migrate/20200818111113_create_item_orders.rb
+++ b/db/migrate/20200818111113_create_item_orders.rb
@@ -1,0 +1,9 @@
+class CreateItemOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :item_orders do |t|
+      t.references :item, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_061737) do
+ActiveRecord::Schema.define(version: 2020_08_18_111113) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,13 @@ ActiveRecord::Schema.define(version: 2020_08_14_061737) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "item_orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_orders_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -68,4 +75,5 @@ ActiveRecord::Schema.define(version: 2020_08_14_061737) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "item_orders", "items"
 end

--- a/spec/factories/item_orders.rb
+++ b/spec/factories/item_orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item_order do
+    
+  end
+end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemOrder, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること
売却済みの商品は、「sold out」の文字が表示されるようになっていること
ログアウト状態でも商品一覧ページを見ることができること